### PR TITLE
android: cap island width on tablets

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -158,6 +158,7 @@ dependencies {
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.lifecycle.viewmodel.navigation3)
     implementation(libs.androidx.navigationevent)
+    testImplementation(libs.junit)
 }
 
 aboutLibraries {

--- a/android/app/src/main/java/me/kavishdevar/librepods/presentation/overlays/IslandWindow.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/presentation/overlays/IslandWindow.kt
@@ -74,6 +74,16 @@ enum class IslandType {
     MOVED_TO_OTHER_DEVICE,
 }
 
+private const val ISLAND_PHONE_WIDTH_RATIO = 0.95f
+private const val ISLAND_TABLET_MAX_WIDTH_DP = 400
+
+internal fun calculateIslandWindowWidth(screenWidthPx: Int, density: Float): Int {
+    val proportionalWidth = (screenWidthPx * ISLAND_PHONE_WIDTH_RATIO).toInt()
+    val maxTabletWidth = (ISLAND_TABLET_MAX_WIDTH_DP * density).toInt()
+
+    return minOf(proportionalWidth, maxTabletWidth)
+}
+
 class IslandWindow(private val context: Context) {
     private val windowManager: WindowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     @SuppressLint("InflateParams")
@@ -170,7 +180,7 @@ class IslandWindow(private val context: Context) {
         else ServiceManager.getService()?.islandOpen = true
 
         val displayMetrics = Resources.getSystem().displayMetrics
-        val width = (displayMetrics.widthPixels * 0.95).toInt()
+        val width = calculateIslandWindowWidth(displayMetrics.widthPixels, displayMetrics.density)
         screenHeight = displayMetrics.heightPixels
 
         val batteryList = ServiceManager.getService()?.getBattery()

--- a/android/app/src/test/java/me/kavishdevar/librepods/presentation/overlays/IslandWindowTest.kt
+++ b/android/app/src/test/java/me/kavishdevar/librepods/presentation/overlays/IslandWindowTest.kt
@@ -1,0 +1,42 @@
+/*
+    LibrePods - AirPods liberated from Apple's ecosystem
+    Copyright (C) 2025 LibrePods contributors
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package me.kavishdevar.librepods.presentation.overlays
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class IslandWindowTest {
+    @Test
+    fun phoneWidthUsesScreenRatio() {
+        assertEquals(PHONE_EXPECTED_WIDTH_PX, calculateIslandWindowWidth(PHONE_SCREEN_WIDTH_PX, DISPLAY_DENSITY))
+    }
+
+    @Test
+    fun tabletWidthIsCapped() {
+        assertEquals(TABLET_EXPECTED_WIDTH_PX, calculateIslandWindowWidth(TABLET_SCREEN_WIDTH_PX, DISPLAY_DENSITY))
+    }
+
+    private companion object {
+        private const val DISPLAY_DENSITY = 3f
+        private const val PHONE_SCREEN_WIDTH_PX = 1080
+        private const val PHONE_EXPECTED_WIDTH_PX = 1026
+        private const val TABLET_SCREEN_WIDTH_PX = 3392
+        private const val TABLET_EXPECTED_WIDTH_PX = 1200
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ hilt = "2.59.2"
 xposed = "101.0.0"
 lifecycleProcess = "2.10.0"
 play = "2.0.2"
+junit = "4.13.2"
 nav3Core = "1.1.2"
 lifecycleViewmodelNav3 = "2.11.0-rc01"
 navevent = "1.1.1"
@@ -58,6 +59,7 @@ libxposed-service = { group = "io.github.libxposed", name = "service", version.r
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
 play-review = { group = "com.google.android.play", name="review", version.ref = "play" }
 play-review-ktx = { group = "com.google.android.play", name="review-ktx", version.ref = "play" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3Core" }
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNav3" }


### PR DESCRIPTION
## Summary
- Cap the Dynamic Island overlay width on tablet-sized displays.
- Keep phone behavior proportional while avoiding oversized tablet overlays.
- Add a unit test for phone and tablet width calculations.

## Issues
Fix #657

## Test verification (RED -> GREEN)
RED before implementation:
```text
e: IslandWindowTest.kt:27:47 Unresolved reference 'calculateIslandWindowWidth'.
e: IslandWindowTest.kt:32:48 Unresolved reference 'calculateIslandWindowWidth'.
```

GREEN with fix:
```text
> Task :app:testFossDebugUnitTest
BUILD SUCCESSFUL
```

Revert proof:
```text
IslandWindowTest > tabletWidthIsCapped FAILED
java.lang.AssertionError at IslandWindowTest.kt:32
2 tests completed, 1 failed
```

Final checks:
```text
./gradlew testFossDebugUnitTest --tests me.kavishdevar.librepods.presentation.overlays.IslandWindowTest
BUILD SUCCESSFUL

./gradlew assembleFossDebug
BUILD SUCCESSFUL
```
