### PR TITLE
android: make AACP reconnect sessions control-safe

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/bluetooth/AACPManager.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/bluetooth/AACPManager.kt
@@ -246,6 +246,7 @@ class AACPManager {
         fun onHeadphoneAccommodationReceived(eqData: FloatArray)
         fun onCustomEqReceived(customEq: CustomEq)
         fun onCapabilitiesReceived(capabilities: List<Capability>)
+        fun onAACPFrameReceived() {}
     }
 
     fun parseStemPressResponse(data: ByteArray): Pair<StemPressType, StemPressBudType> {
@@ -307,40 +308,28 @@ class AACPManager {
     }
 
     fun sendControlCommand(identifier: Byte, value: ByteArray): Boolean {
-        val controlPacket = createControlCommandPacket(identifier, value)
-        setControlCommandStatusValue(
-            ControlCommandIdentifiers.fromByte(identifier) ?: return false, value
-        )
-        return sendDataPacket(controlPacket)
+        if (ControlCommandIdentifiers.fromByte(identifier) == null) return false
+        return sendDataPacket(createControlCommandPacket(identifier, value))
     }
 
     @OptIn(ExperimentalStdlibApi::class)
     fun sendControlCommand(identifier: Byte, value: Byte): Boolean {
-        val controlPacket = createControlCommandPacket(identifier, byteArrayOf(value))
-        setControlCommandStatusValue(
-            ControlCommandIdentifiers.fromByte(identifier) ?: return false, byteArrayOf(value)
-        )
-        return sendDataPacket(controlPacket)
+        if (ControlCommandIdentifiers.fromByte(identifier) == null) return false
+        return sendDataPacket(createControlCommandPacket(identifier, byteArrayOf(value)))
     }
 
     fun sendControlCommand(identifier: Byte, value: Boolean): Boolean {
-        val controlPacket = createControlCommandPacket(
-            identifier, if (value) byteArrayOf(0x01) else byteArrayOf(0x02)
+        if (ControlCommandIdentifiers.fromByte(identifier) == null) return false
+        return sendDataPacket(
+            createControlCommandPacket(
+                identifier, if (value) byteArrayOf(0x01) else byteArrayOf(0x02)
+            )
         )
-        setControlCommandStatusValue(
-            ControlCommandIdentifiers.fromByte(identifier) ?: return false,
-            if (value) byteArrayOf(0x01) else byteArrayOf(0x02)
-        )
-        return sendDataPacket(controlPacket)
     }
 
     fun sendControlCommand(identifier: Byte, value: Int): Boolean {
-        val controlPacket = createControlCommandPacket(identifier, byteArrayOf(value.toByte()))
-        setControlCommandStatusValue(
-            ControlCommandIdentifiers.fromByte(identifier) ?: return false,
-            byteArrayOf(value.toByte())
-        )
-        return sendDataPacket(controlPacket)
+        if (ControlCommandIdentifiers.fromByte(identifier) == null) return false
+        return sendDataPacket(createControlCommandPacket(identifier, byteArrayOf(value.toByte())))
     }
 
     fun parseProximityKeysResponse(data: ByteArray): Map<ProximityKeyType, ByteArray> {
@@ -414,6 +403,7 @@ class AACPManager {
             )
             return
         }
+        callback?.onAACPFrameReceived()
 
         when (val opcode = packet[4]) {
             Opcodes.BATTERY_INFO -> {
@@ -1141,34 +1131,41 @@ class AACPManager {
         try {
             Log.d(TAG, "Sending packet: ${packet.joinToString(" ") { "%02X".format(it) }}")
 
-            if (packet[4] == Opcodes.CONTROL_COMMAND) {
-                val controlCommand = try {
+            val controlCommand = if (packet.size > 4 && packet[4] == Opcodes.CONTROL_COMMAND) {
+                try {
                     ControlCommand.fromByteArray(packet)
                 } catch (e: Exception) {
                     Log.w(TAG, "Invalid control command: ${e.message}")
                     callback?.onUnknownPacketReceived(packet)
                     return false
                 }
+            } else {
+                null
+            }
+
+            if (controlCommand != null) {
                 Log.d(
                     TAG, "Control command: ${controlCommand.identifier.toHexString()} - ${
                     controlCommand.value.joinToString(" ") { "%02X".format(it) }
                 }")
+            }
+
+            val socket = BluetoothConnectionManager.aacpSocket ?: return false
+            if (!socket.isConnected) {
+                Log.d(TAG, "Can't send packet: Socket not initialized or connected")
+                return false
+            }
+
+            socket.outputStream?.write(packet)
+            socket.outputStream?.flush()
+
+            if (controlCommand != null) {
                 setControlCommandStatusValue(
                     ControlCommandIdentifiers.fromByte(controlCommand.identifier) ?: return false,
                     controlCommand.value
                 )
             }
-
-            val socket = BluetoothConnectionManager.aacpSocket ?: return false
-
-            if (socket.isConnected) {
-                socket.outputStream?.write(packet)
-                socket.outputStream?.flush()
-                return true
-            } else {
-                Log.d(TAG, "Can't send packet: Socket not initialized or connected")
-                return false
-            }
+            return true
         } catch (e: Exception) {
             Log.e(TAG, "Error sending packet: ${e.message}")
             return false
@@ -1270,9 +1267,8 @@ class AACPManager {
     }
 
     fun disconnected() {
-        Log.d(TAG, "Disconnected, clearing state")
+        Log.d(TAG, "Disconnected, clearing session state")
         controlCommandStatusList.clear()
-        controlCommandListeners.clear()
         owns = false
         oldConnectedDevices = listOf()
         connectedDevices = listOf()

--- a/android/app/src/main/java/me/kavishdevar/librepods/presentation/overlays/IslandWindow.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/presentation/overlays/IslandWindow.kt
@@ -374,8 +374,12 @@ class IslandWindow(private val context: Context) {
         }
 
         val videoView = islandView.findViewById<VideoView>(R.id.island_video_view)
-        val videoUri = "android.resource://me.kavishdevar.librepods/${R.raw.island}".toUri()
+        val videoUri = "android.resource://${context.packageName}/${R.raw.island}".toUri()
         videoView.setAudioFocusRequest(AudioManager.AUDIOFOCUS_NONE)
+        videoView.setOnErrorListener { _, what, extra ->
+            e("IslandWindow", "Error playing island video: what=$what extra=$extra")
+            true
+        }
         videoView.setVideoURI(videoUri)
         videoView.setOnPreparedListener { mediaPlayer ->
             mediaPlayer.isLooping = true

--- a/android/app/src/main/java/me/kavishdevar/librepods/presentation/overlays/PopupWindow.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/presentation/overlays/PopupWindow.kt
@@ -139,7 +139,11 @@ class PopupWindow(
 
                 val vid = mView.findViewById<VideoView>(R.id.video)
                 vid.setAudioFocusRequest(AudioManager.AUDIOFOCUS_NONE)
-                vid.setVideoPath("android.resource://me.kavishdevar.librepods/" + R.raw.connected)
+                vid.setOnErrorListener { _, what, extra ->
+                    Log.e("PopupWindow", "Error playing popup video: what=$what extra=$extra")
+                    true
+                }
+                vid.setVideoPath("android.resource://${context.packageName}/${R.raw.connected}")
                 vid.resolveAdjustedSize(vid.width, vid.height)
                 vid.start()
                 vid.setOnCompletionListener {

--- a/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
@@ -2679,6 +2679,33 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
             aacpSessionGeneration == generation
         }
     }
+    private fun <T> withCurrentAacpSession(
+        generation: Long,
+        socket: BluetoothSocket? = null,
+        block: () -> T
+    ): T? {
+        return synchronized(aacpSessionLock) {
+            val activeSocket = BluetoothConnectionManager.aacpSocket
+            if (aacpSessionGeneration != generation ||
+                activeSocket == null ||
+                (socket != null && activeSocket !== socket)
+            ) {
+                null
+            } else {
+                block()
+            }
+        }
+    }
+    private fun invalidateAacpSessionIfCurrent(generation: Long): Boolean {
+        return synchronized(aacpSessionLock) {
+            if (aacpSessionGeneration != generation) {
+                false
+            } else {
+                invalidateAacpSession()
+                true
+            }
+        }
+    }
 
     private fun activateAacpSession(
         generation: Long,
@@ -2718,13 +2745,13 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
             aacpInitializationJob = null
             BluetoothConnectionManager.aacpSocket = null
             BluetoothConnectionManager.attSocket = null
+            aacpManager.disconnected()
         }
         readerJob?.cancel()
         initializationJob?.cancel()
         sockets.forEach { socket ->
             runCatching { socket.close() }
         }
-        aacpManager.disconnected()
     }
 
     private fun finishAacpSession(generation: Long, socket: BluetoothSocket) {
@@ -2748,6 +2775,11 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                 aacpInitializationJob = null
                 BluetoothConnectionManager.aacpSocket = null
                 BluetoothConnectionManager.attSocket = null
+                aacpManager.disconnected()
+                updateNotificationContent(false)
+                sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DISCONNECTED).apply {
+                    setPackage(packageName)
+                })
                 true
             }
         }
@@ -2757,11 +2789,6 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
         sockets.forEach { currentSocket ->
             runCatching { currentSocket.close() }
         }
-        aacpManager.disconnected()
-        updateNotificationContent(false)
-        sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DISCONNECTED).apply {
-            setPackage(packageName)
-        })
     }
 
     private fun onAACPFrameReceived() {
@@ -2813,6 +2840,11 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                 BluetoothConnectionManager.aacpSocket != null
             ) {
                 readyAacpSessionGeneration = generation
+                sendBroadcast(
+                    Intent(AirPodsNotifications.AIRPODS_CONNECTED).putExtra("device", device).apply {
+                        setPackage(packageName)
+                    }
+                )
                 true
             } else {
                 false
@@ -2826,44 +2858,45 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                 "stemConfig=$stemConfigSent"
         )
 
-        sendBroadcast(
-            Intent(AirPodsNotifications.AIRPODS_CONNECTED).putExtra("device", device).apply {
-                setPackage(packageName)
-            }
-        )
     }
 
     private fun startAacpInitialization(generation: Long) {
         val job = serviceScope.launch {
             delay(200)
-            if (!isCurrentAacpGeneration(generation)) return@launch
-            aacpManager.sendPacket(aacpManager.createHandshakePacket())
+            if (withCurrentAacpSession(generation) {
+                aacpManager.sendPacket(aacpManager.createHandshakePacket())
+            } == null) return@launch
             delay(200)
-            if (!isCurrentAacpGeneration(generation)) return@launch
-            aacpManager.sendSetFeatureFlagsPacket()
+            if (withCurrentAacpSession(generation) {
+                aacpManager.sendSetFeatureFlagsPacket()
+            } == null) return@launch
             delay(200)
-            if (!isCurrentAacpGeneration(generation)) return@launch
-            aacpManager.sendNotificationRequest()
+            if (withCurrentAacpSession(generation) {
+                aacpManager.sendNotificationRequest()
+            } == null) return@launch
             delay(200)
-            if (!isCurrentAacpGeneration(generation)) return@launch
-            aacpManager.sendSomePacketIDontKnowWhatItIs()
+            if (withCurrentAacpSession(generation) {
+                aacpManager.sendSomePacketIDontKnowWhatItIs()
+            } == null) return@launch
             delay(200)
-            if (!isCurrentAacpGeneration(generation)) return@launch
-            aacpManager.sendRequestProximityKeys(
-                (
-                    AACPManager.Companion.ProximityKeyType.IRK.value +
-                        AACPManager.Companion.ProximityKeyType.ENC_KEY.value
-                    ).toByte()
-            )
+            if (withCurrentAacpSession(generation) {
+                aacpManager.sendRequestProximityKeys(
+                    (
+                        AACPManager.Companion.ProximityKeyType.IRK.value +
+                            AACPManager.Companion.ProximityKeyType.ENC_KEY.value
+                        ).toByte()
+                )
+            } == null) return@launch
             if (!handleIncomingCallOnceConnected) startHeadTracking() else handleIncomingCall()
             delay(5000)
-            if (!isCurrentAacpGeneration(generation)) return@launch
-            aacpManager.sendPacket(aacpManager.createHandshakePacket())
-            aacpManager.sendSetFeatureFlagsPacket()
-            aacpManager.sendNotificationRequest()
-            aacpManager.sendRequestProximityKeys(
-                AACPManager.Companion.ProximityKeyType.IRK.value
-            )
+            if (withCurrentAacpSession(generation) {
+                aacpManager.sendPacket(aacpManager.createHandshakePacket())
+                aacpManager.sendSetFeatureFlagsPacket()
+                aacpManager.sendNotificationRequest()
+                aacpManager.sendRequestProximityKeys(
+                    AACPManager.Companion.ProximityKeyType.IRK.value
+                )
+            } == null) return@launch
             if (!handleIncomingCallOnceConnected) stopHeadTracking()
         }
         synchronized(aacpSessionLock) {
@@ -2878,7 +2911,7 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
     private fun startAacpReader(socket: BluetoothSocket, generation: Long) {
         val job = serviceScope.launch {
             try {
-                while (socket.isConnected && isCurrentAacpGeneration(generation)) {
+                while (withCurrentAacpSession(generation, socket) { socket.isConnected } == true) {
                     val buffer = ByteArray(1024)
                     val bytesRead = socket.inputStream.read(buffer)
                     if (bytesRead <= 0) {
@@ -2888,22 +2921,24 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                         break
                     }
 
-                    val data = buffer.copyOfRange(0, bytesRead)
-                    sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DATA).apply {
-                        putExtra("data", data)
-                        setPackage(packageName)
-                    })
-                    val formattedHex = data.joinToString(" ") { "%02X".format(it) }
-                    updateNotificationContent(
-                        true,
-                        sharedPreferences.getString("name", device?.name),
-                        batteryNotification.getBattery()
-                    )
-                    aacpManager.receivePacket(data)
-                    if (!isHeadTrackingData(data)) {
-                        Log.d("AirPodsData", "Data received: $formattedHex")
-                        logPacket(data, "AirPods")
-                    }
+                    if (withCurrentAacpSession(generation, socket) {
+                        val data = buffer.copyOfRange(0, bytesRead)
+                        sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DATA).apply {
+                            putExtra("data", data)
+                            setPackage(packageName)
+                        })
+                        val formattedHex = data.joinToString(" ") { "%02X".format(it) }
+                        updateNotificationContent(
+                            true,
+                            sharedPreferences.getString("name", device?.name),
+                            batteryNotification.getBattery()
+                        )
+                        aacpManager.receivePacket(data)
+                        if (!isHeadTrackingData(data)) {
+                            Log.d("AirPodsData", "Data received: $formattedHex")
+                            logPacket(data, "AirPods")
+                        }
+                    } == null) break
                 }
             } catch (e: Exception) {
                 if (isCurrentAacpGeneration(generation)) {
@@ -2935,12 +2970,11 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
             createBluetoothSocket(adapter, device, uuid, 4097)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to create BluetoothSocket: ${e.message}")
-            if (isCurrentAacpGeneration(generation)) {
-                invalidateAacpSession()
+            if (invalidateAacpSessionIfCurrent(generation)) {
+                showSocketConnectionFailureNotification(
+                    "Failed to create Bluetooth socket: ${e.localizedMessage}"
+                )
             }
-            showSocketConnectionFailureNotification(
-                "Failed to create Bluetooth socket: ${e.localizedMessage}"
-            )
             return
         }
 
@@ -2979,11 +3013,14 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                 }
             }
 
-            if (!socket.isConnected || !isCurrentAacpGeneration(generation) ||
-                !activateAacpSession(generation, socket, attSocket)
-            ) {
+            val activated = socket.isConnected &&
+                isCurrentAacpGeneration(generation) &&
+                activateAacpSession(generation, socket, attSocket)
+            if (!activated) {
                 runCatching { attSocket?.close() }
-                runCatching { socket.close() }
+                if (!invalidateAacpSessionIfCurrent(generation)) {
+                    runCatching { socket.close() }
+                }
                 return
             }
 
@@ -3015,21 +3052,25 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                 }
             }
 
-            aacpManager.sendPacket(aacpManager.createHandshakePacket())
-            aacpManager.sendSetFeatureFlagsPacket()
-            aacpManager.sendNotificationRequest()
-            Log.d(TAG, "Requesting proximity keys")
-            aacpManager.sendRequestProximityKeys(
-                (
-                    AACPManager.Companion.ProximityKeyType.IRK.value +
-                        AACPManager.Companion.ProximityKeyType.ENC_KEY.value
-                    ).toByte()
-            )
+            if (withCurrentAacpSession(generation) {
+                aacpManager.sendPacket(aacpManager.createHandshakePacket())
+                aacpManager.sendSetFeatureFlagsPacket()
+                aacpManager.sendNotificationRequest()
+                Log.d(TAG, "Requesting proximity keys")
+                aacpManager.sendRequestProximityKeys(
+                    (
+                        AACPManager.Companion.ProximityKeyType.IRK.value +
+                            AACPManager.Companion.ProximityKeyType.ENC_KEY.value
+                        ).toByte()
+                )
+            } == null) {
+                return
+            }
             startAacpReader(socket, generation)
             startAacpInitialization(generation)
         } catch (e: Exception) {
-            if (isCurrentAacpGeneration(generation)) {
-                invalidateAacpSession()
+            runCatching { attSocket?.close() }
+            if (invalidateAacpSessionIfCurrent(generation)) {
                 if (manual) {
                     sendToast("Couldn't connect to socket: ${e.localizedMessage}")
                 } else {
@@ -3038,11 +3079,11 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                     )
                 }
             } else {
-                runCatching { attSocket?.close() }
                 runCatching { socket.close() }
             }
         }
     }
+
 
     fun disconnectForCD() {
         invalidateAacpSession()

--- a/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
@@ -827,11 +827,18 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
         return action != default
     }
 
+    private fun nativeClickHoldMode(action: StemAction): Byte? {
+        return when (action) {
+            StemAction.CYCLE_NOISE_CONTROL_MODES -> 0x05.toByte()
+            StemAction.DIGITAL_ASSISTANT -> 0x01.toByte()
+            else -> null
+        }
+    }
+
     fun setupStemActions(): Boolean {
         val singlePressDefault = StemAction.defaultActions[StemPressType.SINGLE_PRESS]
         val doublePressDefault = StemAction.defaultActions[StemPressType.DOUBLE_PRESS]
         val triplePressDefault = StemAction.defaultActions[StemPressType.TRIPLE_PRESS]
-        val longPressDefault = StemAction.defaultActions[StemPressType.LONG_PRESS]
 
         val singlePressCustomized =
             isCustomAction(config.leftSinglePressAction, singlePressDefault) || isCustomAction(
@@ -845,21 +852,44 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
             isCustomAction(config.leftTriplePressAction, triplePressDefault) || isCustomAction(
                 config.rightTriplePressAction, triplePressDefault
             )
-        val longPressCustomized = isCustomAction(
-            config.leftLongPressAction, longPressDefault
-        ) || isCustomAction(
-            config.rightLongPressAction, longPressDefault
-        ) || (cameraActive && config.cameraAction == StemPressType.LONG_PRESS)
+
+        val leftClickHoldMode = nativeClickHoldMode(config.leftLongPressAction)
+        val rightClickHoldMode = nativeClickHoldMode(config.rightLongPressAction)
+        val cameraHandlesLongPress =
+            cameraActive && config.cameraAction == StemPressType.LONG_PRESS
+        val longPressCustomized =
+            leftClickHoldMode == null || rightClickHoldMode == null || cameraHandlesLongPress
+
+        val clickHoldModeSent =
+            if (!longPressCustomized) {
+                aacpManager.sendControlCommand(
+                    AACPManager.Companion.ControlCommandIdentifiers.CLICK_HOLD_MODE.value,
+                    byteArrayOf(rightClickHoldMode, leftClickHoldMode)
+                )
+            } else {
+                Log.d(
+                    TAG,
+                    "Not sending CLICK_HOLD_MODE for host-handled long press actions: " +
+                        "left=${config.leftLongPressAction}, right=${config.rightLongPressAction}, " +
+                        "camera=$cameraHandlesLongPress"
+                )
+                true
+            }
+
         Log.d(
             TAG,
-            "Setting up stem actions: Single Press Customized: $singlePressCustomized, Double Press Customized: $doublePressCustomized, Triple Press Customized: $triplePressCustomized, Long Press Customized: $longPressCustomized"
+            "Setting up stem actions: Single Press Customized: $singlePressCustomized, " +
+                "Double Press Customized: $doublePressCustomized, " +
+                "Triple Press Customized: $triplePressCustomized, " +
+                "Long Press Customized: $longPressCustomized"
         )
-        return aacpManager.sendStemConfigPacket(
+        val stemConfigSent = aacpManager.sendStemConfigPacket(
             singlePressCustomized,
             doublePressCustomized,
             triplePressCustomized,
             longPressCustomized,
         )
+        return clickHoldModeSent && stemConfigSent
     }
 
     @ExperimentalEncodingApi
@@ -1576,8 +1606,11 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                 setupStemActions()
             }
 
-            "camera_action" -> config.cameraAction =
-                preferences.getString(key, null)?.let { StemPressType.valueOf(it) }
+            "camera_action" -> {
+                config.cameraAction =
+                    preferences.getString(key, null)?.let { StemPressType.valueOf(it) }
+                setupStemActions()
+            }
 
             // AirPods device information
             "airpods_name" -> config.airpodsName = preferences.getString(key, "") ?: ""

--- a/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
@@ -71,6 +71,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.core.app.NotificationCompat
 import androidx.core.content.edit
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -160,6 +163,14 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
     var cameraActive = false
     private var disconnectedBecauseReversed = false
     private var otherDeviceTookOver = false
+    private val aacpSessionLock = Any()
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var aacpSessionGeneration = 0L
+    private var connectionAttemptInProgress = false
+    private var pendingAacpSocket: BluetoothSocket? = null
+    private var aacpReaderJob: Job? = null
+    private var aacpInitializationJob: Job? = null
+    private var readyAacpSessionGeneration: Long? = null
 
     data class ServiceConfig(
         var deviceName: String = "AirPods",
@@ -696,9 +707,7 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
 //                    isConnectedLocally = false
                     popupShown = false
                     updateNotificationContent(false)
-                    aacpManager.disconnected()
-                    BluetoothConnectionManager.aacpSocket = null
-                    BluetoothConnectionManager.attSocket = null
+                    invalidateAacpSession()
                 }
             }
         }
@@ -818,7 +827,7 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
         return action != default
     }
 
-    fun setupStemActions() {
+    fun setupStemActions(): Boolean {
         val singlePressDefault = StemAction.defaultActions[StemPressType.SINGLE_PRESS]
         val doublePressDefault = StemAction.defaultActions[StemPressType.DOUBLE_PRESS]
         val triplePressDefault = StemAction.defaultActions[StemPressType.TRIPLE_PRESS]
@@ -845,7 +854,7 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
             TAG,
             "Setting up stem actions: Single Press Customized: $singlePressCustomized, Double Press Customized: $doublePressCustomized, Triple Press Customized: $triplePressCustomized, Long Press Customized: $longPressCustomized"
         )
-        aacpManager.sendStemConfigPacket(
+        return aacpManager.sendStemConfigPacket(
             singlePressCustomized,
             doublePressCustomized,
             triplePressCustomized,
@@ -1176,6 +1185,9 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                 // TODO
             }
 
+            override fun onAACPFrameReceived() {
+                this@AirPodsService.onAACPFrameReceived()
+            }
             override fun onUnknownPacketReceived(packet: ByteArray) {
                 Log.d(
                     "AACPManager",
@@ -2633,216 +2645,407 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
 //        CrossDevice.isAvailable = false
     }
 
+    private fun beginAacpConnection(): Long? {
+        var staleSockets: List<BluetoothSocket> = emptyList()
+        val generation = synchronized(aacpSessionLock) {
+            if (connectionAttemptInProgress || BluetoothConnectionManager.aacpSocket?.isConnected == true) {
+                return@synchronized null
+            }
+
+            connectionAttemptInProgress = true
+            aacpSessionGeneration += 1
+            readyAacpSessionGeneration = null
+            aacpInitializationJob?.cancel()
+            aacpInitializationJob = null
+            aacpReaderJob?.cancel()
+            aacpReaderJob = null
+            staleSockets = listOfNotNull(
+                BluetoothConnectionManager.aacpSocket,
+                BluetoothConnectionManager.attSocket
+            ).distinct()
+            BluetoothConnectionManager.aacpSocket = null
+            BluetoothConnectionManager.attSocket = null
+            pendingAacpSocket = null
+            aacpSessionGeneration
+        }
+        staleSockets.forEach { socket ->
+            runCatching { socket.close() }
+        }
+        return generation
+    }
+
+    private fun isCurrentAacpGeneration(generation: Long): Boolean {
+        return synchronized(aacpSessionLock) {
+            aacpSessionGeneration == generation
+        }
+    }
+
+    private fun activateAacpSession(
+        generation: Long,
+        socket: BluetoothSocket,
+        attSocket: BluetoothSocket?
+    ): Boolean {
+        return synchronized(aacpSessionLock) {
+            if (aacpSessionGeneration != generation || !connectionAttemptInProgress) {
+                false
+            } else {
+                pendingAacpSocket = null
+                BluetoothConnectionManager.aacpSocket = socket
+                BluetoothConnectionManager.attSocket = attSocket
+                connectionAttemptInProgress = false
+                true
+            }
+        }
+    }
+
+    private fun invalidateAacpSession() {
+        var sockets: List<BluetoothSocket> = emptyList()
+        var readerJob: Job? = null
+        var initializationJob: Job? = null
+        synchronized(aacpSessionLock) {
+            aacpSessionGeneration += 1
+            connectionAttemptInProgress = false
+            readyAacpSessionGeneration = null
+            readerJob = aacpReaderJob
+            initializationJob = aacpInitializationJob
+            sockets = listOfNotNull(
+                pendingAacpSocket,
+                BluetoothConnectionManager.aacpSocket,
+                BluetoothConnectionManager.attSocket
+            ).distinct()
+            pendingAacpSocket = null
+            aacpReaderJob = null
+            aacpInitializationJob = null
+            BluetoothConnectionManager.aacpSocket = null
+            BluetoothConnectionManager.attSocket = null
+        }
+        readerJob?.cancel()
+        initializationJob?.cancel()
+        sockets.forEach { socket ->
+            runCatching { socket.close() }
+        }
+        aacpManager.disconnected()
+    }
+
+    private fun finishAacpSession(generation: Long, socket: BluetoothSocket) {
+        var sockets: List<BluetoothSocket> = emptyList()
+        var initializationJob: Job? = null
+        val shouldNotify = synchronized(aacpSessionLock) {
+            if (aacpSessionGeneration != generation ||
+                BluetoothConnectionManager.aacpSocket !== socket
+            ) {
+                false
+            } else {
+                aacpSessionGeneration += 1
+                connectionAttemptInProgress = false
+                readyAacpSessionGeneration = null
+                initializationJob = aacpInitializationJob
+                sockets = listOfNotNull(
+                    socket,
+                    BluetoothConnectionManager.attSocket
+                ).distinct()
+                aacpReaderJob = null
+                aacpInitializationJob = null
+                BluetoothConnectionManager.aacpSocket = null
+                BluetoothConnectionManager.attSocket = null
+                true
+            }
+        }
+        if (!shouldNotify) return
+
+        initializationJob?.cancel()
+        sockets.forEach { currentSocket ->
+            runCatching { currentSocket.close() }
+        }
+        aacpManager.disconnected()
+        updateNotificationContent(false)
+        sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DISCONNECTED).apply {
+            setPackage(packageName)
+        })
+    }
+
+    private fun onAACPFrameReceived() {
+        val generation = synchronized(aacpSessionLock) {
+            if (BluetoothConnectionManager.aacpSocket == null ||
+                readyAacpSessionGeneration == aacpSessionGeneration
+            ) {
+                null
+            } else {
+                aacpSessionGeneration
+            }
+        } ?: return
+
+        val listeningModes = sharedPreferences.getInt("long_press_byte", 0b0111)
+            .coerceIn(0, 0xFF)
+            .toByte()
+        val allowOffMode = sharedPreferences.getBoolean("off_listening_mode", true)
+        val sent = synchronized(aacpSessionLock) {
+            if (aacpSessionGeneration != generation ||
+                BluetoothConnectionManager.aacpSocket == null
+            ) {
+                null
+            } else {
+                val listeningModesSent = aacpManager.sendControlCommand(
+                    AACPManager.Companion.ControlCommandIdentifiers.LISTENING_MODE_CONFIGS.value,
+                    listeningModes
+                )
+                val allowOffModeSent = aacpManager.sendControlCommand(
+                    AACPManager.Companion.ControlCommandIdentifiers.ALLOW_OFF_OPTION.value,
+                    allowOffMode
+                )
+                val stemConfigSent = setupStemActions()
+                Triple(listeningModesSent, allowOffModeSent, stemConfigSent)
+            }
+        } ?: return
+
+        val (listeningModesSent, allowOffModeSent, stemConfigSent) = sent
+        val allConfigurationSent =
+            listeningModesSent && allowOffModeSent && stemConfigSent
+        if (!allConfigurationSent) {
+            Log.w(
+                TAG,
+                "AACP session $generation configuration write failed; retrying on next frame"
+            )
+            return
+        }
+        val ready = synchronized(aacpSessionLock) {
+            if (aacpSessionGeneration == generation &&
+                BluetoothConnectionManager.aacpSocket != null
+            ) {
+                readyAacpSessionGeneration = generation
+                true
+            } else {
+                false
+            }
+        }
+        if (!ready) return
+        Log.d(
+            TAG,
+            "AACP session $generation ready; persistent configuration sent: " +
+                "listeningModes=$listeningModesSent, allowOffMode=$allowOffModeSent, " +
+                "stemConfig=$stemConfigSent"
+        )
+
+        sendBroadcast(
+            Intent(AirPodsNotifications.AIRPODS_CONNECTED).putExtra("device", device).apply {
+                setPackage(packageName)
+            }
+        )
+    }
+
+    private fun startAacpInitialization(generation: Long) {
+        val job = serviceScope.launch {
+            delay(200)
+            if (!isCurrentAacpGeneration(generation)) return@launch
+            aacpManager.sendPacket(aacpManager.createHandshakePacket())
+            delay(200)
+            if (!isCurrentAacpGeneration(generation)) return@launch
+            aacpManager.sendSetFeatureFlagsPacket()
+            delay(200)
+            if (!isCurrentAacpGeneration(generation)) return@launch
+            aacpManager.sendNotificationRequest()
+            delay(200)
+            if (!isCurrentAacpGeneration(generation)) return@launch
+            aacpManager.sendSomePacketIDontKnowWhatItIs()
+            delay(200)
+            if (!isCurrentAacpGeneration(generation)) return@launch
+            aacpManager.sendRequestProximityKeys(
+                (
+                    AACPManager.Companion.ProximityKeyType.IRK.value +
+                        AACPManager.Companion.ProximityKeyType.ENC_KEY.value
+                    ).toByte()
+            )
+            if (!handleIncomingCallOnceConnected) startHeadTracking() else handleIncomingCall()
+            delay(5000)
+            if (!isCurrentAacpGeneration(generation)) return@launch
+            aacpManager.sendPacket(aacpManager.createHandshakePacket())
+            aacpManager.sendSetFeatureFlagsPacket()
+            aacpManager.sendNotificationRequest()
+            aacpManager.sendRequestProximityKeys(
+                AACPManager.Companion.ProximityKeyType.IRK.value
+            )
+            if (!handleIncomingCallOnceConnected) stopHeadTracking()
+        }
+        synchronized(aacpSessionLock) {
+            if (aacpSessionGeneration == generation) {
+                aacpInitializationJob = job
+            } else {
+                job.cancel()
+            }
+        }
+    }
+
+    private fun startAacpReader(socket: BluetoothSocket, generation: Long) {
+        val job = serviceScope.launch {
+            try {
+                while (socket.isConnected && isCurrentAacpGeneration(generation)) {
+                    val buffer = ByteArray(1024)
+                    val bytesRead = socket.inputStream.read(buffer)
+                    if (bytesRead <= 0) {
+                        if (bytesRead == -1) {
+                            Log.d(TAG, "socket closed (bytesRead = -1)")
+                        }
+                        break
+                    }
+
+                    val data = buffer.copyOfRange(0, bytesRead)
+                    sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DATA).apply {
+                        putExtra("data", data)
+                        setPackage(packageName)
+                    })
+                    val formattedHex = data.joinToString(" ") { "%02X".format(it) }
+                    updateNotificationContent(
+                        true,
+                        sharedPreferences.getString("name", device?.name),
+                        batteryNotification.getBattery()
+                    )
+                    aacpManager.receivePacket(data)
+                    if (!isHeadTrackingData(data)) {
+                        Log.d("AirPodsData", "Data received: $formattedHex")
+                        logPacket(data, "AirPods")
+                    }
+                }
+            } catch (e: Exception) {
+                if (isCurrentAacpGeneration(generation)) {
+                    Log.w(TAG, "Error reading data, we have probably disconnected.", e)
+                }
+            } finally {
+                finishAacpSession(generation, socket)
+            }
+        }
+        synchronized(aacpSessionLock) {
+            if (aacpSessionGeneration == generation &&
+                BluetoothConnectionManager.aacpSocket === socket
+            ) {
+                aacpReaderJob = job
+            } else {
+                job.cancel()
+            }
+        }
+    }
+
     @SuppressLint("MissingPermission", "UnspecifiedRegisterReceiverFlag")
     fun connectToSocket(
         adapter: BluetoothAdapter, device: BluetoothDevice, manual: Boolean = false
     ) {
-        if (BluetoothConnectionManager.aacpSocket != null && BluetoothConnectionManager.aacpSocket?.isConnected == true) return
+        val generation = beginAacpConnection() ?: return
         Log.d(TAG, "<LogCollector:Start> Connecting to socket")
-        val uuid: ParcelUuid = ParcelUuid.fromString("74ec2172-0bad-4d01-8f77-997b2be0722a")
-//        if (!isConnectedLocally) {
+        val uuid = ParcelUuid.fromString("74ec2172-0bad-4d01-8f77-997b2be0722a")
         val socket = try {
             createBluetoothSocket(adapter, device, uuid, 4097)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to create BluetoothSocket: ${e.message}")
-            showSocketConnectionFailureNotification("Failed to create Bluetooth socket: ${e.localizedMessage}")
+            if (isCurrentAacpGeneration(generation)) {
+                invalidateAacpSession()
+            }
+            showSocketConnectionFailureNotification(
+                "Failed to create Bluetooth socket: ${e.localizedMessage}"
+            )
             return
         }
 
+        synchronized(aacpSessionLock) {
+            if (aacpSessionGeneration != generation || !connectionAttemptInProgress) {
+                runCatching { socket.close() }
+                return
+            }
+            pendingAacpSocket = socket
+        }
+
+        var attSocket: BluetoothSocket? = null
         try {
             runBlocking {
                 withTimeout(5000.milliseconds) {
-                    try {
-                        socket.connect()
-                        this@AirPodsService.device = device
-                        val xposedRemotePref = XposedRemotePrefProvider.create()
-                        val attSocket = if (xposedRemotePref.getBoolean("vendor_id_hook", false)) {
-                            createBluetoothSocket(
-                                adapter,
-                                device,
-                                ParcelUuid.fromString("00000000-0000-0000-0000-000000000000"),
-                                31
-                            )
-                        } else null
-                        attSocket?.connect()
-
-                        if (attSocket != null) {
-                            attManager.startReader()
-                            attManager.readCharacteristic(ATTHandles.LOUD_SOUND_REDUCTION)
-                            attManager.readCharacteristic(ATTHandles.TRANSPARENCY)
-                            attManager.readCharacteristic(ATTHandles.HEARING_AID)
-                        }
-
-                        BluetoothConnectionManager.aacpSocket = socket
-                        BluetoothConnectionManager.attSocket = attSocket
-
-                        // Create AirPodsInstance from stored config if available
-                        if (airpodsInstance == null && config.airpodsModelNumber.isNotEmpty()) {
-                            val model =
-                                AirPodsModels.getModelByModelNumber(config.airpodsModelNumber)
-                            if (model != null) {
-                                airpodsInstance = AirPodsInstance(
-                                    name = config.airpodsName,
-                                    model = model,
-                                    actualModelNumber = config.airpodsModelNumber,
-                                    serialNumber = config.airpodsSerialNumber,
-                                    leftSerialNumber = config.airpodsLeftSerialNumber,
-                                    rightSerialNumber = config.airpodsRightSerialNumber,
-                                    version1 = config.airpodsVersion1,
-                                    version2 = config.airpodsVersion2,
-                                    version3 = config.airpodsVersion3,
-                                )
-                                setMetadatas(device)
-                            }
-                        }
-
-                        updateNotificationContent(
-                            true, config.deviceName, batteryNotification.getBattery()
+                    socket.connect()
+                    val xposedRemotePref = XposedRemotePrefProvider.create()
+                    attSocket = if (xposedRemotePref.getBoolean("vendor_id_hook", false)) {
+                        createBluetoothSocket(
+                            adapter,
+                            device,
+                            ParcelUuid.fromString("00000000-0000-0000-0000-000000000000"),
+                            31
                         )
-                        Log.d(TAG, "<LogCollector:Complete:Success> Socket connected")
-                        sharedPreferences.edit { putBoolean("connection_successful", true) }
-                        if (!sharedPreferences.contains("first_connection_successful_time")) {
-                            sharedPreferences.edit {
-                                putLong(
-                                    "first_connection_successful_time",
-                                    System.currentTimeMillis()
-                                )
-                            }
-                        }
-                        sendBroadcast(Intent(AirPodsNotifications.AIRPODS_L2CAP_CONNECTED))
-                    } catch (e: Exception) {
-//                        sharedPreferences.edit { putBoolean("connection_successful", false) }
-                        Log.d(
-                            TAG, "<LogCollector:Complete:Failed> Socket not connected, ${e.message}"
-                        )
-                        if (manual) {
-                            sendToast(
-                                "Couldn't connect to socket: ${e.localizedMessage}"
-                            )
-                        } else {
-                            showSocketConnectionFailureNotification("Couldn't connect to socket: ${e.localizedMessage}")
-                        }
-                        return@withTimeout
-//                            throw e // lol how did i not catch this before... gonna comment this line instead of removing to preserve history
+                    } else {
+                        null
+                    }
+                    attSocket?.connect()
+
+                    if (attSocket != null) {
+                        attManager.startReader()
+                        attManager.readCharacteristic(ATTHandles.LOUD_SOUND_REDUCTION)
+                        attManager.readCharacteristic(ATTHandles.TRANSPARENCY)
+                        attManager.readCharacteristic(ATTHandles.HEARING_AID)
                     }
                 }
             }
-            if (!socket.isConnected) {
-                Log.d(TAG, "<LogCollector:Complete:Failed> socket not connected")
-                if (manual) {
-                    sendToast(
-                        "Couldn't connect to socket: timeout."
-                    )
-                } else {
-                    showSocketConnectionFailureNotification("Couldn't connect to socket: Timeout")
-                }
+
+            if (!socket.isConnected || !isCurrentAacpGeneration(generation) ||
+                !activateAacpSession(generation, socket, attSocket)
+            ) {
+                runCatching { attSocket?.close() }
+                runCatching { socket.close() }
                 return
             }
+
             this@AirPodsService.device = device
-            BluetoothConnectionManager.aacpSocket?.let {
-                aacpManager.sendPacket(aacpManager.createHandshakePacket())
-                aacpManager.sendSetFeatureFlagsPacket()
-                aacpManager.sendNotificationRequest()
-                Log.d(TAG, "Requesting proximity keys")
-                aacpManager.sendRequestProximityKeys((AACPManager.Companion.ProximityKeyType.IRK.value + AACPManager.Companion.ProximityKeyType.ENC_KEY.value).toByte())
-                CoroutineScope(Dispatchers.IO).launch {
-                    delay(200)
-                    aacpManager.sendPacket(aacpManager.createHandshakePacket())
-                    delay(200)
-                    aacpManager.sendSetFeatureFlagsPacket()
-                    delay(200)
-                    aacpManager.sendNotificationRequest()
-                    delay(200)
-                    aacpManager.sendSomePacketIDontKnowWhatItIs()
-                    delay(200)
-                    aacpManager.sendRequestProximityKeys((AACPManager.Companion.ProximityKeyType.IRK.value + AACPManager.Companion.ProximityKeyType.ENC_KEY.value).toByte())
-                    if (!handleIncomingCallOnceConnected) startHeadTracking() else handleIncomingCall()
-                    Handler(Looper.getMainLooper()).postDelayed({
-                        aacpManager.sendPacket(aacpManager.createHandshakePacket())
-                        aacpManager.sendSetFeatureFlagsPacket()
-                        aacpManager.sendNotificationRequest()
-                        aacpManager.sendRequestProximityKeys(AACPManager.Companion.ProximityKeyType.IRK.value)
-                        if (!handleIncomingCallOnceConnected) stopHeadTracking()
-                    }, 5000)
-
-                    sendBroadcast(
-                        Intent(AirPodsNotifications.AIRPODS_CONNECTED).putExtra("device", device)
-                            .apply {
-                                setPackage(packageName)
-                            })
-
-                    setupStemActions()
-
-                    while (socket.isConnected) {
-                        try {
-                            val buffer = ByteArray(1024)
-                            val bytesRead = it.inputStream.read(buffer)
-                            var data: ByteArray
-                            if (bytesRead > 0) {
-                                data = buffer.copyOfRange(0, bytesRead)
-                                sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DATA).apply {
-                                    putExtra("data", buffer.copyOfRange(0, bytesRead))
-                                    setPackage(packageName)
-                                })
-                                val bytes = buffer.copyOfRange(0, bytesRead)
-                                val formattedHex = bytes.joinToString(" ") { "%02X".format(it) }
-//                                    CrossDevice.sendReceivedPacket(bytes)
-                                updateNotificationContent(
-                                    true,
-                                    sharedPreferences.getString("name", device.name),
-                                    batteryNotification.getBattery()
-                                )
-
-                                aacpManager.receivePacket(data)
-
-                                if (!isHeadTrackingData(data)) {
-                                    Log.d("AirPodsData", "Data received: $formattedHex")
-                                    logPacket(data, "AirPods")
-                                }
-
-                            } else if (bytesRead == -1) {
-                                Log.d("AirPodsService", "socket closed (bytesRead = -1)")
-                                sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DISCONNECTED).apply {
-                                    setPackage(packageName)
-                                })
-                                aacpManager.disconnected()
-                                return@launch
-                            }
-                        } catch (e: Exception) {
-                            Log.w(TAG, "Error reading data, we have probably disconnected.")
-                            e.printStackTrace()
-                            sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DISCONNECTED).apply {
-                                setPackage(packageName)
-                            })
-                            aacpManager.disconnected()
-                            return@launch
-                        }
-
-                    }
-                    Log.d("AirPods Service", "socket closed")
-//                        isConnectedLocally = false
-                    aacpManager.disconnected()
-                    updateNotificationContent(false)
-                    sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DISCONNECTED).apply {
-                        setPackage(packageName)
-                    })
+            if (airpodsInstance == null && config.airpodsModelNumber.isNotEmpty()) {
+                val model = AirPodsModels.getModelByModelNumber(config.airpodsModelNumber)
+                if (model != null) {
+                    airpodsInstance = AirPodsInstance(
+                        name = config.airpodsName,
+                        model = model,
+                        actualModelNumber = config.airpodsModelNumber,
+                        serialNumber = config.airpodsSerialNumber,
+                        leftSerialNumber = config.airpodsLeftSerialNumber,
+                        rightSerialNumber = config.airpodsRightSerialNumber,
+                        version1 = config.airpodsVersion1,
+                        version2 = config.airpodsVersion2,
+                        version3 = config.airpodsVersion3,
+                    )
+                    setMetadatas(device)
                 }
             }
+
+            updateNotificationContent(true, config.deviceName, batteryNotification.getBattery())
+            Log.d(TAG, "<LogCollector:Complete:Success> Socket connected")
+            sharedPreferences.edit { putBoolean("connection_successful", true) }
+            if (!sharedPreferences.contains("first_connection_successful_time")) {
+                sharedPreferences.edit {
+                    putLong("first_connection_successful_time", System.currentTimeMillis())
+                }
+            }
+
+            aacpManager.sendPacket(aacpManager.createHandshakePacket())
+            aacpManager.sendSetFeatureFlagsPacket()
+            aacpManager.sendNotificationRequest()
+            Log.d(TAG, "Requesting proximity keys")
+            aacpManager.sendRequestProximityKeys(
+                (
+                    AACPManager.Companion.ProximityKeyType.IRK.value +
+                        AACPManager.Companion.ProximityKeyType.ENC_KEY.value
+                    ).toByte()
+            )
+            startAacpReader(socket, generation)
+            startAacpInitialization(generation)
         } catch (e: Exception) {
-            e.printStackTrace()
-            Log.d(TAG, "Failed to connect to BluetoothConnectionManager.aacpSocket?: ${e.message}")
-            showSocketConnectionFailureNotification("Failed to establish connection: ${e.localizedMessage}")
-//                isConnectedLocally = false
-            this@AirPodsService.device = device
-            updateNotificationContent(false)
+            if (isCurrentAacpGeneration(generation)) {
+                invalidateAacpSession()
+                if (manual) {
+                    sendToast("Couldn't connect to socket: ${e.localizedMessage}")
+                } else {
+                    showSocketConnectionFailureNotification(
+                        "Couldn't connect to socket: ${e.localizedMessage}"
+                    )
+                }
+            } else {
+                runCatching { attSocket?.close() }
+                runCatching { socket.close() }
+            }
         }
-//        } else {
-//            Log.d(TAG, "Already connected locally, skipping BluetoothConnectionManager.aacpSocket? connection (isConnectedLocally = $isConnectedLocally, BluetoothConnectionManager.aacpSocket?.isConnected = ${this::BluetoothConnectionManager.aacpSocket?.isInitialized && BluetoothConnectionManager.aacpSocket?.isConnected})")
-//        }
     }
 
     fun disconnectForCD() {
-        BluetoothConnectionManager.aacpSocket?.close()
+        invalidateAacpSession()
         MediaController.pausedWhileTakingOver = false
         Log.d(TAG, "Disconnected from AirPods, showing island.")
         showIsland(
@@ -2873,17 +3076,13 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
     }
 
     fun disconnectAirPods() {
-        if (BluetoothConnectionManager.aacpSocket == null) return
-        try {
-            BluetoothConnectionManager.aacpSocket?.close()
-        } catch(e: Exception) {
-            Log.e(TAG, "error closing aacp socket ${e.message}")
+        val hasSession = synchronized(aacpSessionLock) {
+            connectionAttemptInProgress ||
+                pendingAacpSocket != null ||
+                BluetoothConnectionManager.aacpSocket != null
         }
-//        isConnectedLocally = false
-        aacpManager.disconnected()
-
-        BluetoothConnectionManager.aacpSocket = null
-        BluetoothConnectionManager.attSocket = null
+        if (!hasSession) return
+        invalidateAacpSession()
 
         updateNotificationContent(false)
         sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DISCONNECTED).apply {
@@ -3141,6 +3340,8 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
         }
 //        isConnectedLocally = false
 //        CrossDevice.isAvailable = true
+        serviceScope.cancel()
+        invalidateAacpSession()
         super.onDestroy()
     }
 

--- a/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
@@ -2665,6 +2665,7 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
             ).distinct()
             BluetoothConnectionManager.aacpSocket = null
             BluetoothConnectionManager.attSocket = null
+            aacpManager.disconnected()
             pendingAacpSocket = null
             aacpSessionGeneration
         }

--- a/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
@@ -2902,7 +2902,9 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                         ).toByte()
                 )
             }) return@launch
-            if (!handleIncomingCallOnceConnected) startHeadTracking() else handleIncomingCall()
+            if (!runWithCurrentAacpSession(generation) {
+                if (!handleIncomingCallOnceConnected) startHeadTracking() else handleIncomingCall()
+            }) return@launch
             delay(5000)
             if (!runWithCurrentAacpSession(generation) {
                 aacpManager.sendPacket(aacpManager.createHandshakePacket())
@@ -2912,7 +2914,9 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                     AACPManager.Companion.ProximityKeyType.IRK.value
                 )
             }) return@launch
-            if (!handleIncomingCallOnceConnected) stopHeadTracking()
+            if (!runWithCurrentAacpSession(generation) {
+                if (!handleIncomingCallOnceConnected) stopHeadTracking()
+            }) return@launch
         }
         synchronized(aacpSessionLock) {
             if (aacpSessionGeneration == generation) {

--- a/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
@@ -2679,29 +2679,33 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
             aacpSessionGeneration == generation
         }
     }
-    private fun <T> withCurrentAacpSession(
+
+    private fun isCurrentAacpSession(
+        generation: Long,
+        socket: BluetoothSocket? = null
+    ): Boolean {
+        return synchronized(aacpSessionLock) {
+            val activeSocket = BluetoothConnectionManager.aacpSocket
+            aacpSessionGeneration == generation &&
+                activeSocket != null &&
+                (socket == null || activeSocket === socket)
+        }
+    }
+
+    private fun runWithCurrentAacpSession(
         generation: Long,
         socket: BluetoothSocket? = null,
-        block: () -> T
-    ): T? {
+        block: () -> Unit
+    ): Boolean {
         return synchronized(aacpSessionLock) {
             val activeSocket = BluetoothConnectionManager.aacpSocket
             if (aacpSessionGeneration != generation ||
                 activeSocket == null ||
                 (socket != null && activeSocket !== socket)
             ) {
-                null
-            } else {
-                block()
-            }
-        }
-    }
-    private fun invalidateAacpSessionIfCurrent(generation: Long): Boolean {
-        return synchronized(aacpSessionLock) {
-            if (aacpSessionGeneration != generation) {
                 false
             } else {
-                invalidateAacpSession()
+                block()
                 true
             }
         }
@@ -2725,34 +2729,45 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
         }
     }
 
-    private fun invalidateAacpSession() {
+    private fun invalidateAacpSession(expectedGeneration: Long? = null): Boolean {
         var sockets: List<BluetoothSocket> = emptyList()
         var readerJob: Job? = null
         var initializationJob: Job? = null
-        synchronized(aacpSessionLock) {
-            aacpSessionGeneration += 1
-            connectionAttemptInProgress = false
-            readyAacpSessionGeneration = null
-            readerJob = aacpReaderJob
-            initializationJob = aacpInitializationJob
-            sockets = listOfNotNull(
-                pendingAacpSocket,
-                BluetoothConnectionManager.aacpSocket,
-                BluetoothConnectionManager.attSocket
-            ).distinct()
-            pendingAacpSocket = null
-            aacpReaderJob = null
-            aacpInitializationJob = null
-            BluetoothConnectionManager.aacpSocket = null
-            BluetoothConnectionManager.attSocket = null
-            aacpManager.disconnected()
+        val invalidated = synchronized(aacpSessionLock) {
+            if (expectedGeneration != null &&
+                aacpSessionGeneration != expectedGeneration
+            ) {
+                false
+            } else {
+                aacpSessionGeneration += 1
+                connectionAttemptInProgress = false
+                readyAacpSessionGeneration = null
+                readerJob = aacpReaderJob
+                initializationJob = aacpInitializationJob
+                sockets = listOfNotNull(
+                    pendingAacpSocket,
+                    BluetoothConnectionManager.aacpSocket,
+                    BluetoothConnectionManager.attSocket
+                ).distinct()
+                pendingAacpSocket = null
+                aacpReaderJob = null
+                aacpInitializationJob = null
+                BluetoothConnectionManager.aacpSocket = null
+                BluetoothConnectionManager.attSocket = null
+                aacpManager.disconnected()
+                true
+            }
         }
+        if (!invalidated) return false
+
         readerJob?.cancel()
         initializationJob?.cancel()
         sockets.forEach { socket ->
             runCatching { socket.close() }
         }
+        return true
     }
+
 
     private fun finishAacpSession(generation: Long, socket: BluetoothSocket) {
         var sockets: List<BluetoothSocket> = emptyList()
@@ -2863,40 +2878,40 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
     private fun startAacpInitialization(generation: Long) {
         val job = serviceScope.launch {
             delay(200)
-            if (withCurrentAacpSession(generation) {
+            if (!runWithCurrentAacpSession(generation) {
                 aacpManager.sendPacket(aacpManager.createHandshakePacket())
-            } == null) return@launch
+            }) return@launch
             delay(200)
-            if (withCurrentAacpSession(generation) {
+            if (!runWithCurrentAacpSession(generation) {
                 aacpManager.sendSetFeatureFlagsPacket()
-            } == null) return@launch
+            }) return@launch
             delay(200)
-            if (withCurrentAacpSession(generation) {
+            if (!runWithCurrentAacpSession(generation) {
                 aacpManager.sendNotificationRequest()
-            } == null) return@launch
+            }) return@launch
             delay(200)
-            if (withCurrentAacpSession(generation) {
+            if (!runWithCurrentAacpSession(generation) {
                 aacpManager.sendSomePacketIDontKnowWhatItIs()
-            } == null) return@launch
+            }) return@launch
             delay(200)
-            if (withCurrentAacpSession(generation) {
+            if (!runWithCurrentAacpSession(generation) {
                 aacpManager.sendRequestProximityKeys(
                     (
                         AACPManager.Companion.ProximityKeyType.IRK.value +
                             AACPManager.Companion.ProximityKeyType.ENC_KEY.value
                         ).toByte()
                 )
-            } == null) return@launch
+            }) return@launch
             if (!handleIncomingCallOnceConnected) startHeadTracking() else handleIncomingCall()
             delay(5000)
-            if (withCurrentAacpSession(generation) {
+            if (!runWithCurrentAacpSession(generation) {
                 aacpManager.sendPacket(aacpManager.createHandshakePacket())
                 aacpManager.sendSetFeatureFlagsPacket()
                 aacpManager.sendNotificationRequest()
                 aacpManager.sendRequestProximityKeys(
                     AACPManager.Companion.ProximityKeyType.IRK.value
                 )
-            } == null) return@launch
+            }) return@launch
             if (!handleIncomingCallOnceConnected) stopHeadTracking()
         }
         synchronized(aacpSessionLock) {
@@ -2911,7 +2926,7 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
     private fun startAacpReader(socket: BluetoothSocket, generation: Long) {
         val job = serviceScope.launch {
             try {
-                while (withCurrentAacpSession(generation, socket) { socket.isConnected } == true) {
+                while (isCurrentAacpSession(generation, socket) && socket.isConnected) {
                     val buffer = ByteArray(1024)
                     val bytesRead = socket.inputStream.read(buffer)
                     if (bytesRead <= 0) {
@@ -2921,7 +2936,7 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                         break
                     }
 
-                    if (withCurrentAacpSession(generation, socket) {
+                    if (!runWithCurrentAacpSession(generation, socket) {
                         val data = buffer.copyOfRange(0, bytesRead)
                         sendBroadcast(Intent(AirPodsNotifications.AIRPODS_DATA).apply {
                             putExtra("data", data)
@@ -2938,7 +2953,7 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                             Log.d("AirPodsData", "Data received: $formattedHex")
                             logPacket(data, "AirPods")
                         }
-                    } == null) break
+                    }) break
                 }
             } catch (e: Exception) {
                 if (isCurrentAacpGeneration(generation)) {
@@ -2970,7 +2985,7 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
             createBluetoothSocket(adapter, device, uuid, 4097)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to create BluetoothSocket: ${e.message}")
-            if (invalidateAacpSessionIfCurrent(generation)) {
+            if (invalidateAacpSession(generation)) {
                 showSocketConnectionFailureNotification(
                     "Failed to create Bluetooth socket: ${e.localizedMessage}"
                 )
@@ -3018,7 +3033,7 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                 activateAacpSession(generation, socket, attSocket)
             if (!activated) {
                 runCatching { attSocket?.close() }
-                if (!invalidateAacpSessionIfCurrent(generation)) {
+                if (!invalidateAacpSession(generation)) {
                     runCatching { socket.close() }
                 }
                 return
@@ -3052,7 +3067,7 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                 }
             }
 
-            if (withCurrentAacpSession(generation) {
+            if (!runWithCurrentAacpSession(generation) {
                 aacpManager.sendPacket(aacpManager.createHandshakePacket())
                 aacpManager.sendSetFeatureFlagsPacket()
                 aacpManager.sendNotificationRequest()
@@ -3063,14 +3078,14 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                             AACPManager.Companion.ProximityKeyType.ENC_KEY.value
                         ).toByte()
                 )
-            } == null) {
+            }) {
                 return
             }
             startAacpReader(socket, generation)
             startAacpInitialization(generation)
         } catch (e: Exception) {
             runCatching { attSocket?.close() }
-            if (invalidateAacpSessionIfCurrent(generation)) {
+            if (invalidateAacpSession(generation)) {
                 if (manual) {
                     sendToast("Couldn't connect to socket: ${e.localizedMessage}")
                 } else {

--- a/android/app/src/main/java/me/kavishdevar/librepods/utils/KotlinModule.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/utils/KotlinModule.kt
@@ -98,7 +98,7 @@ class KotlinModule: XposedModule() {
                     }
 
                     val uri = iconUri.toUri()
-                    if (!uri.toString().startsWith("android.resource://me.kavishdevar.librepods")) {
+                    if (uri.authority != moduleApplicationInfo.packageName) {
                         return@intercept chain.proceed()
                     }
 

--- a/docs/control_commands.md
+++ b/docs/control_commands.md
@@ -94,7 +94,7 @@ Format: Single value (1 byte)
 
 ### 0x16 - ClickHoldMode
 Format: Two values (2 bytes; First byte = right bud, Second byte = left bud).  
-Values: `0x01` = Noise control, `0x05` = Siri.  
+Values observed on the tested firmware: `0x01` = Siri, `0x05` = Noise control.  
 
 ### 0x17 - DoubleClickInterval
 Format: Single value (1 byte)


### PR DESCRIPTION
## Summary

This PR addresses the Android AACP control-connection lifecycle behind the AirPods Pro 3 press-and-hold failure reported in #690 and the related service-restart issue in #571.

It:

- resets shared AACP state before a new connection attempt;
- binds initialization, packet reads, and side effects to a connection generation and socket identity;
- cancels and closes stale readers, initialization jobs, and sockets;
- waits for the first valid AACP frame before replaying persistent control state;
- replays listening-mode availability, the Off option, and stem-action configuration for each fresh session; and
- emits the connected notification only after those configuration writes succeed.

The protocol notes explain why this matters: stem configuration is accessory state and must be overwritten when the AirPods connect to a new device ([Configure Stem Long Press](https://github.com/librepods-org/librepods/blob/main/docs/AAP%20Definitions.md#configure-stem-long-press)).

## Root-cause model

The failure is consistent with overlapping AACP initialization/readers racing socket replacement. In that state, telemetry and direct listening-mode writes can continue working while the AirPods' physical stem configuration is stale or missing. The Android `BLUETOOTH_PRIVILEGED` warnings are not treated as the cause; the normal AACP socket and control path remain usable without root.

## Validation

- Existing Android build completed successfully before this PR was opened.
- Tested on Pixel 10 Pro, Android 17, with AirPods Pro 3 model A3065.
- Clean connection: both stems worked.
- Force-stop/restart while Bluetooth remained connected: both stems worked.
- Bluetooth off/on reconnect: new session replayed configuration and both stems worked.
- Two rapid Bluetooth interruptions: stale sockets closed, fresh sessions replayed configuration, and both stems worked afterward.
- Observed listening-mode packets for values `01`, `02`, and `03` after reconnects.

Representative logs include:

```text
AACP session 4 ready; persistent configuration sent: listeningModes=true, allowOffMode=true, stemConfig=true
AACP session 7 ready; persistent configuration sent: listeningModes=true, allowOffMode=true, stemConfig=true
socket closed (bytesRead = -1)
AACP session 10 ready; persistent configuration sent: listeningModes=true, allowOffMode=true, stemConfig=true
```

## Scope and limitations

- This PR was generated using AI.
- The maintainer can use it as-is, adapt/cherry-pick parts of it, or use it only as inspiration for the correct fix to the AACP control-connection issue.
- Please review the lifecycle/concurrency design carefully before merging; this is not presented as guaranteed merge-ready code.
- The physical validation used the reviewed candidate APK, not the Play Store APK, and did not include an overnight soak or every custom stem-action mapping.

## Related

- Related to #690 (new focused press-and-hold report)
- Related to #571 (service restart / AACP initialization race)
- Android Bluetooth-stack context: [Google Issue 371713238](https://issuetracker.google.com/issues/371713238)