### PR TITLE
fix(linux): stop the takeover firing on non-events with two devices connected

### DIFF
--- a/linux-rust/src/media_controller.rs
+++ b/linux-rust/src/media_controller.rs
@@ -124,6 +124,12 @@ impl MediaController {
         )>,
     ) {
         info!("Starting playback listener loop");
+        // `is_playing` starts false, which is a placeholder rather than an
+        // observation. Whatever is already playing when this loop starts would
+        // otherwise read as playback that just began — and on a reconnect, with
+        // another device holding the audio, that escalates into taking it away
+        // from a device the user was happily listening on.
+        let mut baseline_taken = false;
         loop {
             tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -136,6 +142,26 @@ impl MediaController {
             state.is_playing = is_playing;
             let local_mac = state.local_mac.clone();
             drop(state);
+
+            if !baseline_taken {
+                baseline_taken = true;
+                debug!("Recorded initial playback state ({is_playing}); not a transition");
+                continue;
+            }
+
+            // Losing ownership pauses local players and drops the audio
+            // profile. Players tend to resume on their own once the profile
+            // comes back, and that resume is not the user asking for the audio
+            // — treating it as one starts a tug of war with the device that
+            // just took over, ending with neither side playing.
+            if is_playing && !was_playing {
+                let mut state = self.state.lock().await;
+                if state.i_paused_the_media {
+                    state.i_paused_the_media = false;
+                    debug!("Playback resumed after our own pause; not taking ownership");
+                    continue;
+                }
+            }
 
             if !was_playing && is_playing {
                 let aacp_state = aacp_manager.state.lock().await;
@@ -234,6 +260,19 @@ impl MediaController {
                 debug!("Ear detection disabled, skipping");
                 return;
             }
+        }
+
+        // No previous reading means this is the first report after connecting,
+        // not a change the wearer made. It matters because `old_all_out` is
+        // vacuously true for an empty list, so an already-worn pair looks like
+        // it was just put in: playback resumes, and with a second device
+        // connected the resume escalates into taking the audio away from it.
+        // Record the baseline and wait for a real transition instead.
+        if old_statuses.is_empty() {
+            debug!("First ear reading after connecting: recording baseline, not acting");
+            let mut state = self.state.lock().await;
+            state.old_in_ear_data = new_in_ear_data;
+            return;
         }
 
         if new_has_at_least_one_in && old_all_out {
@@ -428,6 +467,10 @@ impl MediaController {
 
     pub async fn pause_all_media(&self) {
         debug!("Pausing all media (without tracking for resume)");
+
+        // Remember that the pause came from us, so the playback listener does
+        // not mistake the players coming back for the user starting something.
+        self.state.lock().await.i_paused_the_media = true;
 
         let paused_count = tokio::task::spawn_blocking(|| {
             let conn = match Connection::new_session() {

--- a/linux-rust/src/media_controller.rs
+++ b/linux-rust/src/media_controller.rs
@@ -617,22 +617,45 @@ impl MediaController {
         if mac.is_empty() {
             return None;
         }
-        let mac_clone = mac.to_string();
 
-        tokio::task::spawn_blocking(move || {
-            for card in get_card_info_list_sync() {
-                if let Some(device_string) = card.proplist.get_str("device.string")
-                    && device_string.contains(&mac_clone)
-                {
-                    info!("Found audio device index for MAC {}: {}", mac_clone, card.index);
-                    return Some(card.index);
-                }
-            }
-            error!("No matching Bluetooth card found for MAC address: {}", mac_clone);
-            None
-        })
+        // Taking the connection back from another device makes the earbuds
+        // renegotiate, and the card briefly disappears from the sound server
+        // while that happens. A single lookup can land in that window and give
+        // up, leaving the audio nowhere: ownership already taken from the other
+        // device, but no local profile to play through. So poll for a moment.
+        const ATTEMPTS: u32 = 12;
+        const INTERVAL: Duration = Duration::from_millis(250);
+
+        for attempt in 1..=ATTEMPTS {
+            let mac_clone = mac.to_string();
+            let found = tokio::task::spawn_blocking(move || {
+                get_card_info_list_sync().into_iter().find_map(|card| {
+                    let device_string = card.proplist.get_str("device.string")?;
+                    device_string.contains(&mac_clone).then_some(card.index)
+                })
+            })
             .await
-            .unwrap_or(None)
+            .unwrap_or(None);
+
+            if let Some(index) = found {
+                if attempt > 1 {
+                    debug!("Found audio device for {mac} after {attempt} attempts");
+                }
+                info!("Found audio device index for MAC {}: {}", mac, index);
+                return Some(index);
+            }
+
+            if attempt < ATTEMPTS {
+                tokio::time::sleep(INTERVAL).await;
+            }
+        }
+
+        error!(
+            "No matching Bluetooth card found for MAC address: {} after {:?}",
+            mac,
+            INTERVAL * ATTEMPTS
+        );
+        None
     }
 
     pub async fn deactivate_a2dp_profile(&self) {


### PR DESCRIPTION
Found while using the DID hook with an iPhone and a Linux laptop connected to the same AirPods Pro. Four defects, all in `media_controller.rs`, that make the takeover fire when the user did nothing — and with a second device connected, firing means pulling the audio away from a device they were listening on.

## 1. The audio card lookup does not wait

Taking the connection back makes the earbuds renegotiate, and the card drops out of the sound server for a moment. `get_audio_device_index` looked exactly once, so a takeover landing in that window found nothing and gave up.

The failure mode is worse than a missing profile: ownership has already been taken from the other device by then, so the audio ends up nowhere. Playback stops where it was working and never starts here.

```
taking ownership and activating a2dp
hijacking connection by asking AirPods
ERROR No matching Bluetooth card found for MAC CC:22:FE:54:1B:B1
```

Now it polls for up to three seconds.

## 2. Ear detection treats "unknown" as "removed"

`old_all_out` is `.all()` over the previous reading, which is vacuously true for an empty list. LibrePods reinitialises on every reconnect, so the first report of an already-worn pair reads as buds just inserted:

```
AirPods connected: ... initializing
Audio Source: <phone>, type: Media
Ear Detection Status: [InEar, InEar]
Ear Detection - old_in_ear_data: [], new_in_ear_data: [true, true]
... 11s later ...
Media playback started, taking ownership
```

The buds were never removed. The first reading is now recorded as a baseline.

## 3. Playback state has the same shape of bug

`is_playing` starts `false` as a placeholder, so anything already playing when the listener starts reads as playback that just began. A reconnect while media is open takes the audio. The first poll is now a baseline too.

## 4. Losing ownership feeds back into taking it

Losing ownership pauses local players and drops the audio profile; players tend to resume once the profile returns. That resume was indistinguishable from the user pressing play, so it took ownership back from the device that had just claimed it — which pauses this side again:

```
03:09:47  activated A2DP, hijacking
03:09:48  Audio Source: <laptop>, Media
03:09:49  Lost ownership, pausing media and disconnecting audio
03:09:50  Audio Source: <phone>, Media
03:09:50  taking ownership and activating a2dp
03:09:51  Audio Source: <laptop>, Media
03:09:59  Audio Source: 00:00:00:00:00:00, None
```

The two devices trade the audio until neither is playing. `i_paused_the_media` already existed for exactly this but was never set on that path.

## Testing

Ubuntu 26.04, GNOME 50.1 Wayland, AirPods Pro 3, iPhone and laptop both connected via the DID hook (`DeviceID = bluetooth:004c:...` in BlueZ `main.conf`).

Before: restarting the service while the phone was playing took the audio within seconds, and the two devices traded it until both went silent.

After: a restart with media open leaves the phone playing untouched, and pressing play locally still takes the audio as intended.

One limitation is unchanged and out of scope here: if the other device is still actively playing, the earbuds may answer the hijack with `OwnsConnection: 00` and keep it there. That is the earbuds arbitrating, not this code.