### PR TITLE
linux: add setting to toggle media takeover

### DIFF
--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -242,6 +242,18 @@ ApplicationWindow {
                     }
 
                     Switch {
+                        text: qsTr("Take Over Audio When Media Plays")
+                        checked: airPodsTrayApp.mediaTakeoverEnabled
+                        onCheckedChanged: airPodsTrayApp.mediaTakeoverEnabled = checked
+
+                        ToolTip {
+                            visible: parent.hovered
+                            text: qsTr("Automatically connect to the AirPods and take audio from\nother devices when media starts playing on this computer")
+                            delay: 500
+                        }
+                    }
+
+                    Switch {
                         visible: airPodsTrayApp.airpodsConnected
                         text: qsTr("One Bud ANC Mode")
                         checked: airPodsTrayApp.deviceInfo.oneBudANCMode

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -43,6 +43,7 @@ class AirPodsTrayApp : public QObject {
     Q_PROPERTY(AutoStartManager *autoStartManager READ autoStartManager CONSTANT)
     Q_PROPERTY(bool notificationsEnabled READ notificationsEnabled WRITE setNotificationsEnabled NOTIFY notificationsEnabledChanged)
     Q_PROPERTY(int retryAttempts READ retryAttempts WRITE setRetryAttempts NOTIFY retryAttemptsChanged)
+    Q_PROPERTY(bool mediaTakeoverEnabled READ mediaTakeoverEnabled WRITE setMediaTakeoverEnabled NOTIFY mediaTakeoverEnabledChanged)
     Q_PROPERTY(bool hideOnStart READ hideOnStart CONSTANT)
     Q_PROPERTY(DeviceInfo *deviceInfo READ deviceInfo CONSTANT)
     Q_PROPERTY(QString phoneMacStatus READ phoneMacStatus NOTIFY phoneMacStatusChanged)
@@ -90,6 +91,7 @@ public:
         CrossDevice.isEnabled = loadCrossDeviceEnabled();
         setEarDetectionBehavior(loadEarDetectionSettings());
         setRetryAttempts(loadRetryAttempts());
+        m_mediaTakeoverEnabled = loadMediaTakeoverEnabled();
 
         monitor->checkAlreadyConnectedDevices();
         LOG_INFO("AirPodsTrayApp initialized");
@@ -133,6 +135,7 @@ public:
     bool notificationsEnabled() const { return trayManager->notificationsEnabled(); }
     void setNotificationsEnabled(bool enabled) { trayManager->setNotificationsEnabled(enabled); }
     int retryAttempts() const { return m_retryAttempts; }
+    bool mediaTakeoverEnabled() const { return m_mediaTakeoverEnabled; }
     bool hideOnStart() const { return m_hideOnStart; }
     DeviceInfo *deviceInfo() const { return m_deviceInfo; }
     QString phoneMacStatus() const { return m_phoneMacStatus; }
@@ -246,6 +249,17 @@ public slots:
             m_retryAttempts = attempts;
             emit retryAttemptsChanged(attempts);
             saveRetryAttempts(attempts);
+        }
+    }
+
+    void setMediaTakeoverEnabled(bool enabled)
+    {
+        if (m_mediaTakeoverEnabled != enabled)
+        {
+            LOG_DEBUG("Setting media takeover to: " << enabled);
+            m_mediaTakeoverEnabled = enabled;
+            emit mediaTakeoverEnabledChanged(enabled);
+            saveMediaTakeoverEnabled(enabled);
         }
     }
 
@@ -409,6 +423,9 @@ public slots:
 
     int loadRetryAttempts() const { return m_settings->value("bluetooth/retryAttempts", 3).toInt(); }
     void saveRetryAttempts(int attempts) { m_settings->setValue("bluetooth/retryAttempts", attempts); }
+
+    bool loadMediaTakeoverEnabled() const { return m_settings->value("media/takeoverEnabled", true).toBool(); }
+    void saveMediaTakeoverEnabled(bool enabled) { m_settings->setValue("media/takeoverEnabled", enabled); }
 
     void onSystemGoingToSleep()
     {
@@ -887,6 +904,10 @@ private slots:
 public:
     void handleMediaStateChange(MediaController::MediaState state) {
         if (state == MediaController::MediaState::Playing) {
+            if (!m_mediaTakeoverEnabled) {
+                LOG_DEBUG("Media started playing, but media takeover is disabled");
+                return;
+            }
             LOG_INFO("Media started playing, sending disconnect request to Android and taking over audio");
             sendDisconnectRequestToAndroid();
             connectToAirPods(true);
@@ -966,6 +987,7 @@ signals:
     void crossDeviceEnabledChanged(bool enabled);
     void notificationsEnabledChanged(bool enabled);
     void retryAttemptsChanged(int attempts);
+    void mediaTakeoverEnabledChanged(bool enabled);
     void oneBudANCModeChanged(bool enabled);
     void phoneMacStatusChanged();
     void hearingAidEnabledChanged(bool enabled);
@@ -981,6 +1003,7 @@ private:
     QSettings *m_settings;
     AutoStartManager *m_autoStartManager;
     int m_retryAttempts = 3;
+    bool m_mediaTakeoverEnabled = true;
     bool m_hideOnStart = false;
     DeviceInfo *m_deviceInfo;
     BleManager *m_bleManager;


### PR DESCRIPTION
## What

Adds a **Take Over Audio When Media Plays** switch to the Linux app settings, controlling whether the app force-connects to the AirPods (and sends a disconnect request to the phone) when an MPRIS player starts playing.

Persisted as `media/takeoverEnabled`, **defaults to true** so current behavior is unchanged for existing users.

## Why

`handleMediaStateChange` currently reacts to any MPRIS player reporting Playing, unconditionally. With multipoint AirPods this steals audio from the phone in cases the user did not intend:

- a notification or other short sound on the desktop
- a player stuck buffering, which still reports Playing over MPRIS

In those cases the AirPods get yanked away from the phone mid-listen. The feature itself is great; it just needs an off switch for people who share the pods between an active phone and desktop.

## Testing

- Built and running on Arch (Qt 6, AirPods Pro 3 / A3063)
- Toggle off: desktop media no longer grabs the pods from the phone; log shows "Media started playing, but media takeover is disabled"
- Toggle on: unchanged behavior, takeover works
- Setting survives app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)