### PR TITLE
linux: add persistent 'Start Hidden (Tray Only)' setting

### DIFF
--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -236,6 +236,18 @@ ApplicationWindow {
                     }
 
                     Switch {
+                        text: qsTr("Start Hidden (Tray Only)")
+                        checked: airPodsTrayApp.startHidden
+                        onCheckedChanged: airPodsTrayApp.startHidden = checked
+
+                        ToolTip {
+                            visible: parent.hovered
+                            text: qsTr("Launch without showing the main window.\nOpen it from the tray icon instead.\nUseful for tiling window managers.")
+                            delay: 500
+                        }
+                    }
+
+                    Switch {
                         text: qsTr("Enable System Notifications")
                         checked: airPodsTrayApp.notificationsEnabled
                         onCheckedChanged: airPodsTrayApp.notificationsEnabled = checked

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -44,6 +44,7 @@ class AirPodsTrayApp : public QObject {
     Q_PROPERTY(bool notificationsEnabled READ notificationsEnabled WRITE setNotificationsEnabled NOTIFY notificationsEnabledChanged)
     Q_PROPERTY(int retryAttempts READ retryAttempts WRITE setRetryAttempts NOTIFY retryAttemptsChanged)
     Q_PROPERTY(bool hideOnStart READ hideOnStart CONSTANT)
+    Q_PROPERTY(bool startHidden READ startHidden WRITE setStartHidden NOTIFY startHiddenChanged)
     Q_PROPERTY(DeviceInfo *deviceInfo READ deviceInfo CONSTANT)
     Q_PROPERTY(QString phoneMacStatus READ phoneMacStatus NOTIFY phoneMacStatusChanged)
     Q_PROPERTY(bool hearingAidEnabled READ hearingAidEnabled WRITE setHearingAidEnabled NOTIFY hearingAidEnabledChanged)
@@ -134,6 +135,12 @@ public:
     void setNotificationsEnabled(bool enabled) { trayManager->setNotificationsEnabled(enabled); }
     int retryAttempts() const { return m_retryAttempts; }
     bool hideOnStart() const { return m_hideOnStart; }
+    bool startHidden() const { return loadStartHidden(); }
+    void setStartHidden(bool enabled)
+    {
+        saveStartHidden(enabled);
+        emit startHiddenChanged(enabled);
+    }
     DeviceInfo *deviceInfo() const { return m_deviceInfo; }
     QString phoneMacStatus() const { return m_phoneMacStatus; }
     bool hearingAidEnabled() const { return m_deviceInfo->hearingAidEnabled(); }
@@ -406,6 +413,9 @@ public slots:
 
     bool loadNotificationsEnabled() const { return m_settings->value("notifications/enabled", true).toBool(); }
     void saveNotificationsEnabled(bool enabled) { m_settings->setValue("notifications/enabled", enabled); }
+
+    bool loadStartHidden() const { return m_settings->value("window/startHidden", false).toBool(); }
+    void saveStartHidden(bool enabled) { m_settings->setValue("window/startHidden", enabled); }
 
     int loadRetryAttempts() const { return m_settings->value("bluetooth/retryAttempts", 3).toInt(); }
     void saveRetryAttempts(int attempts) { m_settings->setValue("bluetooth/retryAttempts", attempts); }
@@ -965,6 +975,7 @@ signals:
     void earDetectionBehaviorChanged(int behavior);
     void crossDeviceEnabledChanged(bool enabled);
     void notificationsEnabledChanged(bool enabled);
+    void startHiddenChanged(bool enabled);
     void retryAttemptsChanged(int attempts);
     void oneBudANCModeChanged(bool enabled);
     void phoneMacStatusChanged();
@@ -1040,6 +1051,11 @@ int main(int argc, char *argv[]) {
 
         if (QString(argv[i]) == "--hide")
             hideOnStart = true;
+    }
+
+    {
+        QSettings settings("AirPodsTrayApp", "AirPodsTrayApp");
+        hideOnStart = hideOnStart || settings.value("window/startHidden", false).toBool();
     }
 
     QQmlApplicationEngine engine;


### PR DESCRIPTION
## Motivation

LibrePods is a tray app, but the main window pops up at startup whenever it is launched without `--hide`. The built-in auto-start entry already passes `--hide`, but users who start the app some other way — e.g. `spawn-at-startup` in tiling compositors like niri/Hyprland/sway, or launching from an app launcher — get the 400x300 window shown on every boot. On tiling window managers this appears as an unwanted overlay window.

## Changes

Adds a persistent **Start Hidden (Tray Only)** toggle to the settings page:

- New `window/startHidden` QSettings key, exposed to QML as `airPodsTrayApp.startHidden`
- At startup, the effective hide state is `--hide || startHidden`, so the persisted preference works no matter how the app is launched
- Settings switch placed next to *Auto-Start on Login*, with a tooltip explaining the behavior

## Tested

Built on Arch Linux (Qt 6, cmake) and verified under niri: with the setting enabled and **no** `--hide` flag, the process starts and the tray icon works while no window is created (`niri msg windows` shows nothing). The window still opens normally from the tray icon.

No behavior change for users who don't enable the toggle (default `false`).

Note: created with Qwen3.8max as I was annoyed in my niri setup that librepods has this big banner that may look nice on non-tiling managers, but gets in the way of tiling managers, at least on niri.
