### PR TITLE
fix(linux): don't hold the state mutex while sending a packet

### DIFF
--- a/linux-rust/src/bluetooth/aacp.rs
+++ b/linux-rust/src/bluetooth/aacp.rs
@@ -439,8 +439,27 @@ impl AACPManager {
     }
 
     async fn send_packet(&self, data: &[u8]) -> Result<()> {
-        let state = self.state.lock().await;
-        if let Some(sender) = &state.sender {
+        // The sender is cloned and the lock released before awaiting. Holding
+        // the state mutex across a full channel blocks every other task,
+        // including the receive loop, and the manager stops responding
+        // entirely. The timeout turns a stuck mutex into a logged error
+        // instead of a hang with no diagnosis.
+        let sender = match tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            self.state.lock(),
+        )
+        .await
+        {
+            Ok(state) => state.sender.clone(),
+            Err(_) => {
+                error!("send_packet: state mutex held for over 2s, giving up");
+                return Err(Error::from(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "state mutex busy",
+                )));
+            }
+        };
+        if let Some(sender) = sender {
             sender.send(data.to_vec()).await.map_err(|e| {
                 error!("Failed to send packet to channel: {}", e);
                 Error::from(std::io::Error::new(


### PR DESCRIPTION
## Problem

`send_packet` takes the state lock and holds the guard across the channel send:

```rust
let state = self.state.lock().await;
if let Some(sender) = &state.sender {
    sender.send(data.to_vec()).await   // guard still alive here
```

Once the channel fills up, that send blocks with the mutex held. Every other task waiting on the state queues up behind it, the receive loop included — so the socket stops being drained and the manager stops responding altogether. There is no error to go on: the tray goes dead, control commands never reach the buds, and the log simply stops.

## Fix

Clone the sender and drop the lock before awaiting. A timeout on acquiring the lock turns a stuck mutex into a logged error rather than a silent hang, which is what made this hard to diagnose in the first place.

## How it showed up

Steady packet traffic is enough to trigger it. The high-res microphone stream from #655 sends and receives continuously, and on AirPods Pro 3 (Fedora 44, PipeWire 1.6.8) it wedged the app within seconds of enabling — repeatedly, until this change. Afterwards the same workload runs without stalls, and the tray keeps responding while audio flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gq252FQ6wFFNMq5wYGtTX3