### PR TITLE
Fix linux CI workflow

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get install -y build-essential cmake ninja-build \
             qt6-base-dev qt6-declarative-dev qt6-svg-dev \
             qt6-tools-dev qt6-tools-dev-tools qt6-connectivity-dev \
-            libxkbcommon-dev
+            libxkbcommon-dev libpulse-dev
 
       - name: Build project
         working-directory: linux


### PR DESCRIPTION
Fixes the bug where compiling for Linux using the default workflow crashes due to a missing package. 