### PR TITLE
android: open the app on quick settings tile long-press

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -88,6 +88,12 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!-- Long-press on the quick settings tile lands here instead of the system app info screen. -->
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
             <!-- <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
Long-pressing the ANC quick settings tile currently opens the Android system app info screen for LibrePods, which is a dead end.

SystemUI's `CustomTile.getLongClickIntent()` builds an implicit `android.service.quicksettings.action.QS_TILE_PREFERENCES` intent scoped to the tile's package, and falls back to Settings' app info screen when nothing resolves it. Nothing in the app declared that action.

`MainActivity` now declares an intent filter for it. Its start destination (`Screen.AirPodsSettings`) already holds the noise control section the tile drives, so no extra deep-link plumbing is needed — long-press lands directly on the ANC controls.

Manifest-only change; not verified on-device yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182Sr9MEn5UyZSj8PQd4M4e